### PR TITLE
pr 增加ES6模块支持

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,7 @@ function PluginImportToCDN(options: Options): Plugin[] {
                 const jsCode = !isBuild
                     ? ''
                     : data
-                        .map(p => p.pathList.map(url => `<script src="${url}"></script>`).join('\n'))
+                        .map(p => p.pathList.map(url => `<script src="${url}"${p.es6 ? 'type="module"' : ''}></script>`).join('\n'))
                         .join('\n')
 
                 return html.replace(

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,9 @@ function PluginImportToCDN(options: Options): Plugin[] {
                 return userConfig
             },
             transformIndexHtml(html) {
-                const cssCode = data
+                const cssCode = !isBuild
+                    ? ''
+                    :data
                     .map(v => v.cssList.map(css => `<link href="${css}" rel="stylesheet">`).join('\n'))
                     .filter(v => v)
                     .join('\n')

--- a/src/type.ts
+++ b/src/type.ts
@@ -4,6 +4,7 @@ export interface Module {
     var: string
     path: string | string[]
     css?: string | string[]
+    es6?: boolean
 }
 
 export interface Options {


### PR DESCRIPTION
ES6模块的CDN在使用时，必须在script标签内加入 type="module"
否则会出现 Uncaught SyntaxError: Unexpected token 'export' 错误