### PR TITLE
add optional htmlPrefix and jsOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -140,15 +140,20 @@ function PluginImportToCDN(options: Options): Plugin[] {
                 return userConfig
             },
             transformIndexHtml(html) {
+
                 const cssCode = data
-                    .map(v => v.cssList.map(css => `<link href="${css}" rel="stylesheet">`).join('\n'))
+                    .map(v => v.cssList.map(css => `${v.htmlPrefix}<link href="${css}" rel="stylesheet">`).join('\n'))
                     .filter(v => v)
                     .join('\n')
 
                 const jsCode = !isBuild
                     ? ''
                     : data
-                        .map(p => p.pathList.map(url => `<script src="${url}"></script>`).join('\n'))
+                        .map(p => p.pathList.map(url => {
+                            const jsOptions = p.jsOptions ? ` ${p.jsOptions}` : ''
+                            return `${p.htmlPrefix}<script${jsOptions} src="${url}"></script>`
+                        }
+                        ).join('\n'))
                         .join('\n')
 
                 return html.replace(

--- a/src/type.ts
+++ b/src/type.ts
@@ -4,6 +4,8 @@ export interface Module {
     var: string
     path: string | string[]
     css?: string | string[]
+    htmlPrefix?: string
+    jsOptions?: string
 }
 
 export interface Options {


### PR DESCRIPTION
This change adds two new options, that I needed.

1) `htmlPrefix` give you the option to prepend anything before the inserted tags, in my case I inserted two tabs, so that the `<script>` tags fit properly with my indented html code.
2) `jsOptions` allows you to insert options into the script tag, e.g. `defer`.

Example:
```
{
  name: 'vue',
  var: 'Vue',
  path: 'dist/vue.global.prod.min.js',
  htmlPrefix: '    ',
  jsOptions: 'defer'
}
```

Results in:

```
<!DOCTYPE html>
<html lang="en">
  <head>
[...]
    <title>Vite App</title>
    <script defer src="https://cdn.jsdelivr.net/npm/vue@3.2.47/dist/vue.global.prod.min.js"></script>
```